### PR TITLE
Debug vercel google auth redirect loop

### DIFF
--- a/apps/frontend/app/(auth)/auth/login/page.tsx
+++ b/apps/frontend/app/(auth)/auth/login/page.tsx
@@ -11,6 +11,14 @@ export default async function LoginPage({
   // Check if user is already logged in
   const resolvedSearchParams = await searchParams;
 
+  // If OAuth provider redirected here with a code, forward it to our callback handler
+  const code = (resolvedSearchParams as any)?.code as string | undefined;
+  const next = (resolvedSearchParams as any)?.next as string | undefined;
+  if (code) {
+    const nextSuffix = next ? `&next=${encodeURIComponent(next)}` : "";
+    redirect(`/auth/callback?code=${encodeURIComponent(code)}${nextSuffix}`);
+  }
+
   const supabase = await createClient();
   const {
     data: { user },

--- a/apps/frontend/lib/actions/auth-actions.ts
+++ b/apps/frontend/lib/actions/auth-actions.ts
@@ -3,6 +3,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import { cookies } from "next/headers";
+import { headers } from "next/headers";
 
 export async function signIn(formData: FormData) {
   const email = formData.get("email") as string;
@@ -36,14 +37,15 @@ export async function signUp(formData: FormData) {
 
   const supabase = await createClient();
 
+  const hdrs = await headers();
+  const origin = hdrs.get("origin") || process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+
   const { error } = await supabase.auth.signUp({
     email,
     password,
     options: {
       // This ensures the user is redirected to your site after email confirmation
-      emailRedirectTo: `${
-        process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
-      }/auth/callback`,
+      emailRedirectTo: `${origin}/auth/callback`,
     },
   });
 
@@ -69,12 +71,13 @@ export async function signOut() {
 export async function signInWithGoogle() {
   const supabase = await createClient();
 
+  const hdrs = await headers();
+  const origin = hdrs.get("origin") || process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider: "google",
     options: {
-      redirectTo: `${
-        process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
-      }/auth/callback`,
+      redirectTo: `${origin}/auth/callback`,
       queryParams: {
         access_type: "offline",
         prompt: "consent",

--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -1,16 +1,19 @@
 import type { NextConfig } from "next";
 
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+
 const nextConfig: NextConfig = {
   images: {
-    remotePatterns: [
-      {
-        protocol: "https",
-        hostname:
-          process.env.NEXT_PUBLIC_SUPABASE_URL?.replace("https://", "") || "",
-        port: "",
-        pathname: "/storage/**",
-      },
-    ],
+    remotePatterns: supabaseUrl
+      ? [
+          {
+            protocol: "https",
+            hostname: supabaseUrl.replace("https://", ""),
+            port: "",
+            pathname: "/storage/**",
+          },
+        ]
+      : [],
   },
 };
 


### PR DESCRIPTION
Fixes Supabase OAuth redirect loop on Vercel by dynamically generating callback URLs and handling auth codes on the login page.

The redirect loop occurred because Google's OAuth callback sometimes landed on `/auth/login` with a `code` parameter, which was not handled, causing the app to re-redirect to login. Additionally, hardcoding `redirectTo` URLs was brittle for Vercel's dynamic preview domains.

---
<a href="https://cursor.com/background-agent?bcId=bc-e13763dc-2fcf-4085-a99e-1ccf439c0264">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e13763dc-2fcf-4085-a99e-1ccf439c0264">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

